### PR TITLE
enable calculating embeddings on text block windows

### DIFF
--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -79,6 +79,12 @@ logging.config.dictConfig(DEFAULT_LOGGING)
     default=None,
     help="Optionally limit the number of text samples to process. Useful for debugging.",
 )
+@click.option(
+    "--use-text-block-window",
+    is_flag=True,
+    required=False,
+    help="Whether to encode the text blocks with a window of a block either side, rather than just the text blocks.",
+)
 def run_as_cli(
     input_dir: str,
     output_dir: str,
@@ -86,6 +92,7 @@ def run_as_cli(
     redo: bool,
     device: str,
     limit: Optional[int],
+    use_text_block_window: bool = False,
 ):
     """
     Run CLI to produce embeddings from document parser JSON outputs.
@@ -111,6 +118,7 @@ def run_as_cli(
         redo=redo,
         device=device,
         limit=limit,
+        use_text_block_window=use_text_block_window,
     )
 
 
@@ -121,6 +129,7 @@ def run_embeddings_generation(
     redo: bool,
     device: str,
     limit: Optional[int],
+    use_text_block_window: bool = False,
 ):
     """
     Run CLI to produce embeddings from document parser JSON outputs.
@@ -239,7 +248,11 @@ def run_embeddings_generation(
                 f"Encoding text using model {encoder_name}.",
             )
             description_embedding, text_embeddings = encode_parser_output(
-                encoder, task, config.ENCODING_BATCH_SIZE, device=device
+                encoder,
+                task,
+                config.ENCODING_BATCH_SIZE,
+                device=device,
+                use_text_block_window=use_text_block_window,
             )
 
             combined_embeddings = (

--- a/src/ml.py
+++ b/src/ml.py
@@ -45,6 +45,15 @@ class SBERTEncoder(SentenceEncoder):
             model_name, cache_folder=config.INDEX_ENCODER_CACHE_FOLDER
         )
 
+    def get_n_tokens(self, text: str) -> int:
+        """Return the number of tokens in the text."""
+
+        tokenized = self.encoder[0].tokenizer(
+            text, return_attention_mask=False, return_token_type_ids=False
+        )
+
+        return len(tokenized["input_ids"])
+
     def encode(self, text: str, device: Optional[str] = None) -> np.ndarray:
         """Encode a string, return a numpy array.
 
@@ -58,7 +67,11 @@ class SBERTEncoder(SentenceEncoder):
         return self.encoder.encode(text, device=device, show_progress_bar=False)
 
     def encode_batch(
-        self, text_batch: List[str], batch_size: int = 32, device: Optional[str] = None
+        self,
+        text_batch: List[str],
+        batch_size: int = 32,
+        device: Optional[str] = None,
+        experimental_use_sliding_window: bool = False,
     ) -> np.ndarray:
         """Encode a batch of strings, return a numpy array.
 
@@ -70,9 +83,66 @@ class SBERTEncoder(SentenceEncoder):
         Returns:
             np.ndarray
         """
+        if experimental_use_sliding_window:
+            return self._encode_batch_using_sliding_window(
+                text_batch, batch_size=batch_size, device=device
+            )
+
         return self.encoder.encode(
             text_batch, batch_size=batch_size, show_progress_bar=False, device=device
         )
+
+    def _encode_batch_using_sliding_window(
+        self, text_batch: list[str], batch_size: int = 32, device: Optional[str] = None
+    ):
+        """
+        Encode a batch of strings accommodating long texts using a sliding window.
+
+        For args, see encode_batch.
+        """
+
+        def sliding_window(text: str, window_size: int, stride: int):
+            # Split the text into overlapping windows with the specified size and stride
+            windows = [
+                text[i : i + window_size]
+                for i in range(0, len(text), stride)
+                if i + window_size <= len(text)
+            ]
+            return windows
+
+        max_seq_length = self.encoder.max_seq_length
+        assert isinstance(max_seq_length, int)
+
+        # Split the texts based on length and apply sliding window only to longer texts
+        processed_texts = []
+        window_lengths = []
+
+        for text in text_batch:
+            if self.get_n_tokens(text) > max_seq_length:
+                windows = sliding_window(
+                    text, max_seq_length, max_seq_length // 2
+                )  # Use max_seq_length as window size and half of it as stride
+                processed_texts.extend(windows)
+                window_lengths.append(len(windows))
+            else:
+                processed_texts.append(text)
+                window_lengths.append(1)
+
+        embeddings = self.encode_batch(
+            processed_texts, batch_size=batch_size, device=device
+        )
+
+        reduced_embeddings = []
+
+        for length in window_lengths:
+            if length > 1:
+                reduced_embeddings.append(np.mean(embeddings[:length], axis=0))
+                embeddings = embeddings[length:]
+            else:
+                reduced_embeddings.append(embeddings[0])
+                embeddings = embeddings[1:]
+
+        return np.vstack(reduced_embeddings)
 
     @property
     def dimension(self) -> int:

--- a/src/ml.py
+++ b/src/ml.py
@@ -7,7 +7,16 @@ from sentence_transformers import SentenceTransformer
 import numpy as np
 
 from src import config
-from src.utils import sliding_window
+
+
+def sliding_window(text: str, window_size: int, stride: int):
+    """Split the text into overlapping windows."""
+    windows = [
+        text[i : i + window_size]
+        for i in range(0, len(text), stride)
+        if i + window_size <= len(text)
+    ]
+    return windows
 
 
 class SentenceEncoder(ABC):

--- a/src/ml.py
+++ b/src/ml.py
@@ -7,6 +7,7 @@ from sentence_transformers import SentenceTransformer
 import numpy as np
 
 from src import config
+from src.utils import sliding_window
 
 
 class SentenceEncoder(ABC):
@@ -101,15 +102,6 @@ class SBERTEncoder(SentenceEncoder):
         For args, see encode_batch.
         """
 
-        def sliding_window(text: str, window_size: int, stride: int):
-            # Split the text into overlapping windows with the specified size and stride
-            windows = [
-                text[i : i + window_size]
-                for i in range(0, len(text), stride)
-                if i + window_size <= len(text)
-            ]
-            return windows
-
         max_seq_length = self.encoder.max_seq_length
         assert isinstance(max_seq_length, int)
 
@@ -120,7 +112,7 @@ class SBERTEncoder(SentenceEncoder):
         for text in text_batch:
             if self.get_n_tokens(text) > max_seq_length:
                 windows = sliding_window(
-                    text, max_seq_length, max_seq_length // 2
+                    text, window_size=max_seq_length, stride=max_seq_length // 2
                 )  # Use max_seq_length as window size and half of it as stride
                 processed_texts.extend(windows)
                 window_lengths.append(len(windows))

--- a/src/ml.py
+++ b/src/ml.py
@@ -20,7 +20,11 @@ class SentenceEncoder(ABC):
 
     @abstractmethod
     def encode_batch(
-        self, text_batch: List[str], batch_size: int, device: Optional[str] = None
+        self,
+        text_batch: List[str],
+        batch_size: int,
+        device: Optional[str] = None,
+        experimental_use_sliding_window: bool = False,
     ) -> np.ndarray:
         """Encode a batch of strings, return a numpy array."""
         raise NotImplementedError

--- a/src/test/test_ml.py
+++ b/src/test/test_ml.py
@@ -16,3 +16,21 @@ def test_encoder():
     assert isinstance(encoder.encode_batch(["Hello world!"] * 100), np.ndarray)
 
     assert encoder.dimension == 384
+
+
+def test_encoder_sliding_window():
+    """Assert that we can encode long texts using a sliding window."""
+
+    encoder = SBERTEncoder(config.SBERT_MODELS[0])
+
+    long_text = "Hello world! " * 50
+    short_text = "Hello world!"
+
+    batch_to_encode = [short_text, long_text, short_text, short_text]
+    embeddings = encoder._encode_batch_using_sliding_window(
+        batch_to_encode, batch_size=32
+    )
+
+    assert isinstance(embeddings, np.ndarray)
+    assert embeddings.shape[0] == len(batch_to_encode)
+    assert embeddings.shape[1] == encoder.dimension

--- a/src/test/test_ml.py
+++ b/src/test/test_ml.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from src import config
-from src.ml import SBERTEncoder
+from src.ml import SBERTEncoder, sliding_window
 
 
 def test_encoder():
@@ -38,3 +38,15 @@ def test_encoder_sliding_window():
     assert np.array_equal(embeddings[0, :], embeddings[2, :])
     assert np.array_equal(embeddings[0, :], embeddings[3, :])
     assert not np.array_equal(embeddings[0, :], embeddings[1, :])
+
+
+def test_sliding_window():
+    """Tests that the sliding_window function returns the correct embeddings."""
+    text = "Hello world! " * 50
+    window_size = 10
+    stride = 5
+
+    windows = sliding_window(text=text, window_size=window_size, stride=stride)
+
+    assert windows[0] == "Hello worl"
+    assert windows[1] == " world! He"

--- a/src/test/test_ml.py
+++ b/src/test/test_ml.py
@@ -34,3 +34,7 @@ def test_encoder_sliding_window():
     assert isinstance(embeddings, np.ndarray)
     assert embeddings.shape[0] == len(batch_to_encode)
     assert embeddings.shape[1] == encoder.dimension
+
+    assert np.array_equal(embeddings[0, :], embeddings[2, :])
+    assert np.array_equal(embeddings[0, :], embeddings[3, :])
+    assert not np.array_equal(embeddings[0, :], embeddings[1, :])

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -5,7 +5,7 @@ from cpr_data_access.parser_models import BlockType, ParserOutput, PDFTextBlock
 
 from cli.test.conftest import test_pdf_file_json  # noqa: F401
 from src import config
-from src.ml import SBERTEncoder, sliding_window
+from src.ml import SBERTEncoder
 from src.utils import (
     filter_on_block_type,
     replace_text_blocks,
@@ -155,15 +155,3 @@ def test_encode_indexer_input(test_pdf_file_json):  # noqa: F811
 
 # TODO get_Text2EmbeddingsInput_array
 #   TODO needs s3 files, local files, of the form json IndexerInput objects
-
-
-def test_sliding_window():
-    """Tests that the sliding_window function returns the correct embeddings."""
-    text = "Hello world! " * 50
-    window_size = 10
-    stride = 5
-
-    windows = sliding_window(text=text, window_size=window_size, stride=stride)
-
-    assert windows[0] == "Hello worl"
-    assert windows[1] == " world! He"

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -5,14 +5,13 @@ from cpr_data_access.parser_models import BlockType, ParserOutput, PDFTextBlock
 
 from cli.test.conftest import test_pdf_file_json  # noqa: F401
 from src import config
-from src.ml import SBERTEncoder
+from src.ml import SBERTEncoder, sliding_window
 from src.utils import (
     filter_on_block_type,
     replace_text_blocks,
     filter_blocks,
     get_ids_with_suffix,
     encode_parser_output,
-    sliding_window,
 )
 
 

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -12,6 +12,7 @@ from src.utils import (
     filter_blocks,
     get_ids_with_suffix,
     encode_parser_output,
+    sliding_window,
 )
 
 
@@ -155,3 +156,15 @@ def test_encode_indexer_input(test_pdf_file_json):  # noqa: F811
 
 # TODO get_Text2EmbeddingsInput_array
 #   TODO needs s3 files, local files, of the form json IndexerInput objects
+
+
+def test_sliding_window():
+    """Tests that the sliding_window function returns the correct embeddings."""
+    text = "Hello world! " * 50
+    window_size = 10
+    stride = 5
+
+    windows = sliding_window(text=text, window_size=window_size, stride=stride)
+
+    assert windows[0] == "Hello worl"
+    assert windows[1] == " world! He"

--- a/src/utils.py
+++ b/src/utils.py
@@ -224,13 +224,3 @@ def get_Text2EmbeddingsInput_array(
         )
         for id_ in files_to_process_ids
     ]
-
-
-def sliding_window(text: str, window_size: int, stride: int):
-    """Split the text into overlapping windows."""
-    windows = [
-        text[i : i + window_size]
-        for i in range(0, len(text), stride)
-        if i + window_size <= len(text)
-    ]
-    return windows

--- a/src/utils.py
+++ b/src/utils.py
@@ -98,6 +98,7 @@ def encode_parser_output(
     input_obj: ParserOutput,
     batch_size: int,
     device: Optional[str] = None,
+    use_text_block_window: bool = False,
 ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Encode a parser output object.
@@ -116,6 +117,8 @@ def encode_parser_output(
     )
 
     text_blocks = input_obj.get_text_blocks()
+    if use_text_block_window:
+        pass
 
     if text_blocks:
         text_embeddings = encoder.encode_batch(
@@ -197,3 +200,13 @@ def get_Text2EmbeddingsInput_array(
         )
         for id_ in files_to_process_ids
     ]
+
+
+def sliding_window(text: str, window_size: int, stride: int):
+    """Split the text into overlapping windows."""
+    windows = [
+        text[i : i + window_size]
+        for i in range(0, len(text), stride)
+        if i + window_size <= len(text)
+    ]
+    return windows

--- a/src/utils.py
+++ b/src/utils.py
@@ -110,6 +110,7 @@ def encode_parser_output(
     :param input_obj: parser output object
     :param batch_size: batch size for encoding text blocks
     :param device: device to use for encoding
+    :param use_text_block_window: whether to use a block around each text block for encoding
     """
 
     description_embedding = encoder.encode(
@@ -117,14 +118,37 @@ def encode_parser_output(
     )
 
     text_blocks = input_obj.get_text_blocks()
+    text_to_encode = []
+
     if use_text_block_window:
-        pass
+        text_to_encode = []
+
+        for idx in range(len(text_blocks)):
+            if idx == 0:
+                idxs_in_window = [idx, idx + 1]
+            elif idx == len(text_blocks) - 1:
+                idxs_in_window = [idx - 1, idx]
+            else:
+                idxs_in_window = [
+                    idx - 1,
+                    idx,
+                    idx + 1,
+                ]
+
+            text_to_encode.append(
+                "\n".join(text_blocks[i].to_string() for i in idxs_in_window)
+            )
+
+    else:
+        text_to_encode = [block.to_string() for block in text_blocks]
 
     if text_blocks:
         text_embeddings = encoder.encode_batch(
-            [block.to_string() for block in text_blocks],
+            text_to_encode,
             batch_size=batch_size,
             device=device,
+            # TODO: we always use a sliding window here. Do we want this?
+            experimental_use_sliding_window=True,
         )
     else:
         text_embeddings = None


### PR DESCRIPTION
# In this PR

- add sliding window function to encoder to enable full capture of texts longer than the model context window
- add `--use-text-block-window` flag to let embeddings generation run on windows

Note, **both with and without windows now runs using the new sliding window capability.** This is a good thing! If it works we should stick it into product, to ensure that all of each text block is captured in its embedding.

No change is needed to the indexer – I'll just load this set of embeddings in instead of the old ones and update the queries to use the windows.

# How this is tested

Added both unit and CLI tests for the new features.